### PR TITLE
Implement GCS storage; resolves #1

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"fmt"
 	"image"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"code.google.com/p/goauth2/oauth/jwt"
+	gcs "code.google.com/p/google-api-go-client/storage/v1beta1"
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/s3"
 )
@@ -17,6 +21,10 @@ const (
 	awsKeyEnvVar    = "AWS_ACCESS_KEY_ID"
 	awsSecretEnvVar = "AWS_SECRET_ACCESS_KEY"
 	s3BucketEnvVar  = "PIXLSERV_S3_BUCKET"
+
+	gcsIssEnvVar    = "GCS_ISS"
+	gcsKeyEnvVar    = "GCS_KEY"
+	gcsBucketEnvVar = "PIXLSERV_GCS_BUCKET"
 )
 
 var (
@@ -39,6 +47,9 @@ func storageInit() error {
 	if os.Getenv(awsKeyEnvVar) != "" && os.Getenv(awsSecretEnvVar) != "" && os.Getenv(s3BucketEnvVar) != "" {
 		storageImpl = new(s3Storage)
 		log.Println("Using S3 storage")
+	} else if os.Getenv(gcsIssEnvVar) != "" && os.Getenv(gcsKeyEnvVar) != "" && os.Getenv(gcsBucketEnvVar) != "" {
+		storageImpl = new(gcsStorage)
+		log.Println("Using GCS storage")
 	} else {
 		storageImpl = new(localStorage)
 		log.Println("Using local storage")
@@ -200,4 +211,86 @@ func (s *s3Storage) imageExists(imagePath string) bool {
 	}
 
 	return false
+}
+
+// gcsStorage is a storage implementation using Google Cloud Storage
+
+type gcsStorage struct {
+	client  *http.Client
+	service *gcs.Service
+	bucket  string
+}
+
+func (s *gcsStorage) init() error {
+	jwtToken := jwt.NewToken(os.Getenv(gcsIssEnvVar), gcs.DevstorageRead_writeScope, []byte(os.Getenv(gcsKeyEnvVar)))
+	oauthToken, err := jwtToken.Assert(http.DefaultClient)
+	if err != nil {
+		return err
+	}
+
+	client := (&jwt.Transport{jwtToken, oauthToken, http.DefaultTransport}).Client()
+
+	service, err := gcs.New(client)
+	if err != nil {
+		return err
+	}
+
+	s.client = client
+	s.service = service
+	s.bucket = os.Getenv(gcsBucketEnvVar)
+
+	return nil
+}
+
+func (s *gcsStorage) loadImage(imagePath string) (image.Image, string, error) {
+	obj, err := s.service.Objects.Get(s.bucket, imagePath).Do()
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := s.client.Get(obj.Media.Link)
+	buf := &bytes.Buffer{}
+	_, err = io.Copy(buf, resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, "", err
+	}
+
+	format := strings.TrimLeft(filepath.Ext(imagePath), ".")
+	image, err := readImage(buf.Bytes(), format)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return image, format, nil
+}
+
+func (s *gcsStorage) saveImage(img image.Image, format string, imagePath string) (int, error) {
+	buffer := &bytes.Buffer{}
+	err := writeImage(img, format, buffer)
+	if err != nil {
+		return 0, err
+	}
+
+	size := buffer.Len()
+	_, err = s.service.Objects.Insert(s.bucket, &gcs.Object{Name: imagePath}).Media(buffer).Do()
+	if err != nil {
+		return 0, err
+	}
+	return size, err
+}
+
+func (s *gcsStorage) deleteImage(imagePath string) error {
+	return s.service.Objects.Delete(s.bucket, imagePath).Do()
+}
+
+func (s *gcsStorage) imageExists(imagePath string) bool {
+	obj, err := s.service.Objects.Get(s.bucket, imagePath).Do()
+	if err != nil {
+		return false
+	}
+	return obj != nil
 }


### PR DESCRIPTION
Build and run:

```
go build && GCS_ISS=? GCS_KEY=? PIXLSERV_GCS_BUCKET=? ./pixlserv run config/example.yaml
```

I have omitted the values of the environment variables above. 

I have tested this against a test Google Cloud Storage bucket, and it works. I can send you the credentials (privately; may be email, or direct message via Twitter?) of the test bucket I created if you want to test it on your end, as the process is a bit tedious, imo. 

To test, all you have to is run the above command with the environment variable values in place.

For Google Cloud Storage, `GCS_ISS` is something that looks like an email address, a pretty long one actually! And `GCS_KEY` is a private key (approx 1.1KB in size).
