### PR TITLE
method signature has changed for uuid.SwitchFormat

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -25,7 +25,7 @@ var (
 
 func init() {
 	// Change the UUID format to remove surrounding braces and dashes
-	uuid.SwitchFormat(uuid.Clean, true)
+	uuid.SwitchFormat(uuid.Clean)
 }
 
 func authInit() error {


### PR DESCRIPTION
go get was raising following error
`./auth.go:28: too many arguments in call to uuid.SwitchFormat`
